### PR TITLE
tests(music recognition): fixed tests

### DIFF
--- a/tests/music_recognition_test.py
+++ b/tests/music_recognition_test.py
@@ -3,7 +3,7 @@ import io
 import pytest
 import time
 from .test_tools import url_validator
-from ..music_recognition import recognize, get_files_in_db, upload_to_db_protected, delete_id_from_db
+from ..music_recognition import get_files_in_db, upload_to_db_protected, delete_id_from_db
 from ..music_recognition import get_id_from_title, get_musical_metadata, get_human_readable_db
 from ..music_recognition import delete_from_db, delete_id_from_db_protected_for_web, MusicDuplicationError
 from ..music_recognition import list_container_files_and_results, add_to_container_recognizer
@@ -83,23 +83,6 @@ def init_uploaded_file_bytes():
     """
     TEST_UPLOADED_FILE = io.BytesIO(TEST_FILE_CONTENT)
     TEST_UPLOADED_FILE.filename = 'Raggae_Soundsystem_intro.mp3'
-
-
-def test_non_existing_track_aac():
-    assert not recognize(os.path.join(DIR_PATH, 'Panoramaxx_sample.aac'))
-
-
-def test_non_existing_famous_track():
-    assert not recognize(os.path.join(DIR_PATH, 'Space_Oddity_sample.wav'))
-
-
-def test_existing_famous_track():
-    assert recognize(os.path.join(DIR_PATH, 'Billie_Jean_sample.wav'))
-
-
-def test_music_recognition_error(wrong_file_format_setup):
-    assert not recognize(os.path.join(DIR_PATH, 'wrong_file_format.txt'))
-    assert not os.path.exists(WRONG_FILE_FORMAT)
 
 
 def test_get_files_in_db():


### PR DESCRIPTION
For consecutive test runs - Added 5 seconds sleep in between tests in order to get ACRCloud correct request-results (tests often have requests at the beginning and at the end. The next test might not get the results of the API request after the last test final API request processed in ACRCloud servers).

For consecutive test runs - file pointer has to be restarted. Used total reinitialization of the file constant variable.

Recognize is no longer in use, thus removing unnecessary tests.
