### PR TITLE
fix: Different Service Account handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,20 +6,24 @@ from loguru import logger
 from dotenv.main import load_dotenv
 load_dotenv()
 
+PROJECT_ID = environ.get("PROJECT_ID")
 GOOGLE_PRIVATE_KEY_ID = environ.get("GOOGLE_PRIVATE_KEY_ID")
 GOOGLE_PRIVATE_KEY = environ.get("GOOGLE_PRIVATE_KEY", "").replace("\\n", "\n")
+GOOGLE_CLIENT_EMAIL = environ.get("GOOGLE_CLIENT_EMAIL")
+GOOGLE_CLIENT_ID = environ.get("GOOGLE_CLIENT_ID")
+GOOGLE_CLIENT_x509_CERT_URL = environ.get("GOOGLE_CLIENT_x509_CERT_URL")
 
 CREDENTIALS = {
     "type": "service_account",
-    "project_id": "supple-portal-395117",
+    "project_id": f"{PROJECT_ID}",
     "private_key_id": f"{GOOGLE_PRIVATE_KEY_ID}",
     "private_key": f"-----BEGIN PRIVATE KEY-----{GOOGLE_PRIVATE_KEY}-----END PRIVATE KEY-----\n",
-    "client_email": "spot-id@supple-portal-395117.iam.gserviceaccount.com",
-    "client_id": "114206747933036399061",
+    "client_email": f"{GOOGLE_CLIENT_EMAIL}",
+    "client_id": f"{GOOGLE_CLIENT_ID}",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
     "token_uri": "https://oauth2.googleapis.com/token",
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/spot-id%40supple-portal-395117.iam.gserviceaccount.com",
+    "client_x509_cert_url": f"{GOOGLE_CLIENT_x509_CERT_URL}",
     "universe_domain": "googleapis.com"
 }
 


### PR DESCRIPTION
Instead of changing code to use the new Google Service Account, now the Deployed Container can be redeployed using different environment variables containing the new Google Service Account credentials.
