### PR TITLE
ref: Clean Stories Directory Correction

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -70,9 +70,6 @@ def sync_user_stories(drive: Drive) -> None:
                         logger.warning(f"Encountered an error downloading file {story_metadata['id']}. Skipping file...")
 
     logger.success('Done syncing all stories uploaded today by users who tagged at least once a location SPOT follows')
-    time.sleep(30)  # To avoid OS Errors (files are still being used)
-    logger.info('Clearing stories directory...')
-    instagram_bot.clean_stories_directory()
 
 
 def get_acrcloud_ids_from_drive_id(drive_id: str) -> list:

--- a/sync-stories.py
+++ b/sync-stories.py
@@ -21,3 +21,6 @@ if __name__ == "__main__":
             logger.success(f'Completed sync with no errors at {date_now}')
 
         time.sleep(60 * COOLDOWN_MINUTES)
+
+        logger.info('Clearing stories directory...')
+        IGBOT.clean_stories_directory()


### PR DESCRIPTION
Stories cache directory cleanup should be used only in case of repeated use of Instagram stories download to make sure not to overflow the Docker container.
