### PR TITLE
fix: Remove 'artist' & 'album' Metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,14 +36,12 @@ def get_database_songs():
 def upload_song():
     audio_file = request.files.get("file")
     title = request.form.get("title")
-    artist = request.form.get("artist")
-    album = request.form.get("album")
 
-    if not all([audio_file, title, artist]):
+    if not all([audio_file, title]):
         return jsonify(error="Missing required parameters."), 400
 
     try:
-        upload_to_db_protected(audio_file=audio_file, title=title, artist=artist, album=album)
+        upload_to_db_protected(audio_file=audio_file, title=title)
         return jsonify(message="Song uploaded successfully.")
     except Exception as e:
         logger.error(f"Server error uploading song. Traceback:\n{traceback.format_exc()}")

--- a/tests/logic_test.py
+++ b/tests/logic_test.py
@@ -6,7 +6,9 @@ LOCATION = 'art club'
 
 
 def test_location_logic(drive):
-    recognized_stories = location_logic(location=LOCATION, drive=drive, day=26, month=8, year=2023, end_day=26, end_month=8, end_year=2023)
+    recognized_stories = location_logic(location=LOCATION, drive=drive,
+                                        day=26, month=8, year=2023,
+                                        end_day=26, end_month=8, end_year=2023)
     print(f"Recognized Stories: {recognized_stories}")
     first_story_url = recognized_stories[0]['drive_url']
     first_story_download_url = recognized_stories[0]['download_url']


### PR DESCRIPTION
Frontend no longer uses or displays 'artist' & 'album' metadata so no need to expect them or keep track of them.
