### PR TITLE
ref(SyncStories): Update Date On Success

### DIFF
--- a/sync-stories.py
+++ b/sync-stories.py
@@ -8,13 +8,20 @@ from instagram_bot import IGBOT
 COOLDOWN_MINUTES = 30  # Not too much, not too little.
 
 
+def update_date(igbot: IGBOT, drive_obj: Drive):
+    """Update the date_now variable with the current date."""
+    current_date = datetime.datetime.today().date()
+    logger.debug(f"Updating date to {current_date}")
+    drive_obj.date_now = current_date
+    igbot.date_now = current_date
+    return current_date
+
+
 if __name__ == "__main__":
     drive = Drive()
     instagram_bot = IGBOT()
+    date_now = update_date(instagram_bot, drive)
     while True:
-        date_now = datetime.datetime.today().date()
-        drive.date_now = date_now
-        instagram_bot.date_now = date_now
         logger.info(f'Synchronizing at {date_now}')
         try:
             from logic import master_sync
@@ -24,6 +31,7 @@ if __name__ == "__main__":
         else:
             logger.success(f'Completed sync with no errors at {date_now}')
             time.sleep(60 * COOLDOWN_MINUTES)
+            date_now = update_date(instagram_bot, drive)
 
         logger.info('Clearing stories directory...')
         IGBOT.clean_stories_directory()


### PR DESCRIPTION
To avoid missing stories (past 00:00 of the next day) update the date to current date only if no errors occurred syncing stories (otherwise it will scan again stories from yesterday even though it is past 00:00)
